### PR TITLE
Fix comparing a Money object to a non-Money object

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -14,7 +14,7 @@ class Money
   end
   
   def <=>(other)
-    cents <=> other.cents
+    cents <=> other.to_money.cents
   end
   
   def +(other)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -147,7 +147,7 @@ describe Money do
   end
   
   it "should be comparable with non-money objects" do
-    @money.should_not == nil
+    (Money.new(1) > 0).should be_true
   end
   
   describe "frozen with amount of $1" do


### PR DESCRIPTION
When comparing a money object to a non-money object, you get an error.

Money.new(1) > 0

results in "undefined method `cents' for 0:Fixnum". This failing test and patch fixes it. Let me know if you have any questions. Thanks.

-Ryan
